### PR TITLE
Fixed automatically timer reset in fullscreen

### DIFF
--- a/SplitShow/BeamerTimerController.h
+++ b/SplitShow/BeamerTimerController.h
@@ -20,6 +20,9 @@ typedef enum : NSUInteger {
 
 @property BeamerTimerMode timerMode;
 
+@property NSTimeInterval timerValue;
+
+- (instancetype)initWithTimeInterval: (NSTimeInterval)initialValue;
 - (void)initTimer:(NSTimeInterval)initialValue;
 - (void)startTimer;
 - (void)stopTimer;

--- a/SplitShow/BeamerTimerController.m
+++ b/SplitShow/BeamerTimerController.m
@@ -10,7 +10,7 @@
 
 @interface BeamerTimerController ()
 
-@property NSTimeInterval timerValue;
+
 @property NSTimeInterval initialValue;
 @property NSTimer *timer;
 
@@ -47,6 +47,19 @@
 
     return self;
 }
+
+
+- (instancetype)initWithTimeInterval: (NSTimeInterval)initialValue
+{
+  self = [self init];
+  
+  [self initTimer:initialValue];
+  
+  return self;
+  
+}
+
+
 
 - (void)initTimer:(NSTimeInterval)initialValue
 {

--- a/SplitShow/BeamerTimerController.m
+++ b/SplitShow/BeamerTimerController.m
@@ -88,7 +88,7 @@
 
 - (void)resetTimer
 {
-    [self initTimer:self.initialValue];
+    [self initTimer:0];
 }
 
 - (void)toggleTimerButton:(NSButton*)sender

--- a/SplitShow/SplitShowController.h
+++ b/SplitShow/SplitShowController.h
@@ -36,6 +36,8 @@
 @property NSArray *presentationModes;
 @property NSInteger presentationMode;
 
+@property NSTimeInterval timerState;
+
 - (BOOL)readFromURL:(NSURL*)file error:(NSError*__autoreleasing *)error;
 
 - (void)cancel:(id)sender;

--- a/SplitShow/SplitShowController.m
+++ b/SplitShow/SplitShowController.m
@@ -88,6 +88,8 @@ void displayReconfigurationCallback(CGDirectDisplayID display, CGDisplayChangeSu
 
         self.presentationMode  = [self getPresentationModeForSlideMode:self.presentation.slideMode];
     }
+  
+    self.timerState = 0;
 
     return (self.presentation != nil);
 }
@@ -163,7 +165,7 @@ void displayReconfigurationCallback(CGDirectDisplayID display, CGDisplayChangeSu
         [fullScreenWindow setContentView:fullScreenViewController.beamerView];
         [fullScreenWindow setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];
 
-        BeamerTimerController *timerController = [[BeamerTimerController alloc] init];
+      BeamerTimerController *timerController = [[BeamerTimerController alloc] initWithTimeInterval:self.timerState];
         [fullScreenViewController.beamerView addSubview:timerController.timerView];
 
         fullScreenWindowController = [[NSWindowController alloc] initWithWindow:fullScreenWindow];
@@ -197,6 +199,15 @@ void displayReconfigurationCallback(CGDirectDisplayID display, CGDisplayChangeSu
     {
         NSWindowController *fullScreenWindowController = fullScreen[@"windowController"];
         BeamerViewController *fullScreenViewController = fullScreen[@"viewController"];
+      
+        BeamerTimerController *fullScreenTimerController = fullScreen[@"timerController"];
+      
+        if (fullScreenTimerController != nil)
+        {
+          self.timerState = fullScreenTimerController.timerValue;
+        }
+      
+      
 
         [fullScreenViewController unregisterController:nil];
         [fullScreenWindowController close];
@@ -214,6 +225,7 @@ void displayReconfigurationCallback(CGDirectDisplayID display, CGDisplayChangeSu
 
     BeamerDocumentSlideMode slideMode = [self getSlideModeForPresentationMode:self.presentationMode];
 
+    self.timerState = 0;
     self.currentSlideIndex = 0;
     self.currentSlideLayout = [self.presentation getSlideLayoutForSlideMode:slideMode];
     self.currentSlideCount = [self.currentSlideLayout[@"content"] count];
@@ -224,6 +236,7 @@ void displayReconfigurationCallback(CGDirectDisplayID display, CGDisplayChangeSu
 - (void)reloadPresentation:(id)sender
 {
     [self readFromURL:self.presentation.documentURL error:nil];
+    self.timerState = 0;
 }
 
 - (void)presentPrevSlide


### PR DESCRIPTION
The timer state is automatically reset when a new pdf is loaded or it
is reloaded. Otherwise, it should be manually reset by using the reset
button in fullscreen mode